### PR TITLE
[JAG-287] stop banner on prod

### DIFF
--- a/ldregistry/templates/structure/_service-bar.vm
+++ b/ldregistry/templates/structure/_service-bar.vm
@@ -7,7 +7,7 @@
    ##     </span>
    ##     $msg.get('service.beta.description', 'TBD')
    ## </div>
-#if($request.getServerName().contains("dev.codes.wmo.int") || $request.getServerName().contians("ci.codes.wmo.int"))
+#if($request.getServerName().contains("dev.codes.wmo.int") || $request.getServerName().contains("ci.codes.wmo.int"))
     <div class="row">
         <div class="non-operational-banner">This is a test website – some features and links may not work, and data may be incorrect.</div>
     </div>

--- a/ldregistry/templates/structure/_service-bar.vm
+++ b/ldregistry/templates/structure/_service-bar.vm
@@ -7,7 +7,7 @@
    ##     </span>
    ##     $msg.get('service.beta.description', 'TBD')
    ## </div>
-#if($request.getServerName().includes("dev.codes.wmo.int") || $request.getServerName().includes("ci.codes.wmo.int"))
+#if($request.getServerName().contains("dev.codes.wmo.int") || $request.getServerName().contians("ci.codes.wmo.int"))
     <div class="row">
         <div class="non-operational-banner">This is a test website – some features and links may not work, and data may be incorrect.</div>
     </div>

--- a/ldregistry/templates/structure/_service-bar.vm
+++ b/ldregistry/templates/structure/_service-bar.vm
@@ -7,7 +7,7 @@
    ##     </span>
    ##     $msg.get('service.beta.description', 'TBD')
    ## </div>
-#if($request.getServerName().contains("dev.codes.wmo.int") || $request.getServerName().contains("ci.codes.wmo.int"))
+#if($request.getServerName().contains("ci.codes.wmo.int"))
     <div class="row">
         <div class="non-operational-banner">This is a test website – some features and links may not work, and data may be incorrect.</div>
     </div>

--- a/ldregistry/templates/structure/_service-bar.vm
+++ b/ldregistry/templates/structure/_service-bar.vm
@@ -7,7 +7,7 @@
    ##     </span>
    ##     $msg.get('service.beta.description', 'TBD')
    ## </div>
-#if(!$request.getServerName().equals("codes.wmo.int"))
+#if($request.getServerName().includes("dev.codes.wmo.int") || $request.getServerName().includes("ci.codes.wmo.int"))
     <div class="row">
         <div class="non-operational-banner">This is a test website – some features and links may not work, and data may be incorrect.</div>
     </div>

--- a/ldregistry/templates/structure/_service-bar.vm
+++ b/ldregistry/templates/structure/_service-bar.vm
@@ -7,7 +7,7 @@
    ##     </span>
    ##     $msg.get('service.beta.description', 'TBD')
    ## </div>
-#if($request.getServerName().contains("ci.codes.wmo.int"))
+#if($request.getServerName().contains("dev.codes.wmo.int") || $request.getServerName().contains("ci.codes.wmo.int"))
     <div class="row">
         <div class="non-operational-banner">This is a test website – some features and links may not work, and data may be incorrect.</div>
     </div>


### PR DESCRIPTION
Jira: [JAG-287](https://metoffice.atlassian.net/browse/JAG-287)
Description: Changed the logic for displaying the banner, so that it only appears when on dev or CI (rather than displaying if not prod)

Testing:
- Deploying a dev instance, the banner appears as expected
<img width="1226" height="143" alt="image" src="https://github.com/user-attachments/assets/8c7f044f-fdb0-4fb0-8044-e5f883d5f218" />

- Editing the if statement to remove the check for ` $request.getServerName().contains("dev.codes.wmo.int") `, and deploying a dev instance, the banner does not appear

<img width="1222" height="323" alt="image" src="https://github.com/user-attachments/assets/862ffa4e-234a-4385-a6ff-5ba60cdb5f77" />



Tasks:
- [x] Update conditional
- [x] Test


[JAG-287]: https://metoffice.atlassian.net/browse/JAG-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ