### PR TITLE
[JAG-216/240/242] Various

### DIFF
--- a/ldregistry/templates/main/_render-register-as-list.vm
+++ b/ldregistry/templates/main/_render-register-as-list.vm
@@ -24,11 +24,11 @@
           #if( !$memitem.hasResourceValue("reg:status", "reg:statusReserved") )
           <tr>
           	## When might we not have an $memitem?
-              <td>$memitem.getPropertyValue("reg:notation").lexicalForm</td>
-          	<td>
-              #if($member.hasResourceValue("rdf:type", "reg:Register"))<span class="glyphicon glyphicon-folder-open"></span> &nbsp; #end
-              <a href="#linkhref($memitem)" title="$memitem.uRI">$member.name</a>
-            </td>
+              <td>
+                  #if($member.hasResourceValue("rdf:type", "reg:Register"))<span class="glyphicon glyphicon-folder-open"></span> &nbsp; #end
+                  <a href="#linkhref($memitem)" title="$memitem.uRI">$memitem.getPropertyValue("reg:notation").lexicalForm</a>
+              </td>
+              <td>$member.name</td>
               <td>#tdescription($member,"",70)</td>
 ##            <td>
 ##              #foreach($ty in $member.listPropertyValues("rdf:type"))#linkfor($ty)#if( $foreach.hasNext ), #end#end

--- a/ldregistry/templates/text-search.vm
+++ b/ldregistry/templates/text-search.vm
@@ -12,7 +12,7 @@
                 #end
 
                  *#
-                #set($path = $item.uRI.replaceAll("^/","").replaceAll("/"," / ")))
+                #set($path = $item.uRI.substring($registry.baseURI.length()).replaceAll("/"," / ")))
                 #if($path.lastIndexOf(" / ") > 0)
                   $path.substring(0, $path.lastIndexOf(" / "))
                 #end

--- a/ldregistry/templates/text-search.vm
+++ b/ldregistry/templates/text-search.vm
@@ -2,6 +2,15 @@
             <tr>
               <td>$item.getPropertyValue("reg:notation").lexicalForm</td>
               <td>
+                #set($itemUri = $item.uRI.substring($registry.baseURI.length()))
+                #set($itemPath = $itemUri.replaceAll("^/","").replaceAll("/"," / "))
+                #set($lastSlashIndex = $itemPath.lastIndexOf(" / "))
+                #if($lastSlashIndex > 0)
+                  #set($parentPath = $itemPath.substring(0, $lastSlashIndex))
+                  $parentPath
+                #end
+              </td>
+              <td>
                 #if($entity.hasResourceValue("rdf:type", "reg:Register"))<span class="glyphicon glyphicon-folder-open"></span> &nbsp; #end
                 <a href="#linkhref($item)" title="$item.uRI">$entity.name</a>
               </td>
@@ -39,6 +48,7 @@
       <thead>
         <tr>
           <th>$msg['registerItem.notation.label']</th>
+          <th>$msg['registerItem.register.label']</th>
           <th>$msg['registerItem.name.label']</th>
           <th>$msg['registerItem.description.label']</th>
 ##          <th>$msg['registerItem.types.label']</th>

--- a/ldregistry/templates/text-search.vm
+++ b/ldregistry/templates/text-search.vm
@@ -12,7 +12,7 @@
                 #end
 
                  *#
-                #set($path = $item.uRI.substring($registry.baseURI.length()).replaceAll("^/","").replaceAll("/"," / ")))
+                #set($path = $item.uRI.substring($registry.baseURI.length()).replaceAll("^/","").replaceAll("/"," / "))
                 #set($pathEndIndex = $path.lastIndexOf(" / "))
                 #if($pathEndIndex > 0)
                   $path.substring(0, $pathEndIndex)

--- a/ldregistry/templates/text-search.vm
+++ b/ldregistry/templates/text-search.vm
@@ -2,16 +2,6 @@
             <tr>
               <td>$item.getPropertyValue("reg:notation").lexicalForm</td>
               <td>
-                #*
-                #set($itemUri = $item.uRI.substring($registry.baseURI.length()))
-                #set($itemPath = $itemUri.replaceAll("^/","").replaceAll("/"," / "))
-                #set($lastSlashIndex = $itemPath.lastIndexOf(" / "))
-                #if($lastSlashIndex > 0)
-                  #set($parentPath = $itemPath.substring(0, $lastSlashIndex))
-                  $parentPath
-                #end
-
-                 *#
                 #set($path = $item.uRI.substring($registry.baseURI.length()).replaceAll("^/","").replaceAll("/"," / "))
                 #set($pathEndIndex = $path.lastIndexOf(" / "))
                 #if($pathEndIndex > 0)

--- a/ldregistry/templates/text-search.vm
+++ b/ldregistry/templates/text-search.vm
@@ -2,12 +2,19 @@
             <tr>
               <td>$item.getPropertyValue("reg:notation").lexicalForm</td>
               <td>
+                #*
                 #set($itemUri = $item.uRI.substring($registry.baseURI.length()))
                 #set($itemPath = $itemUri.replaceAll("^/","").replaceAll("/"," / "))
                 #set($lastSlashIndex = $itemPath.lastIndexOf(" / "))
                 #if($lastSlashIndex > 0)
                   #set($parentPath = $itemPath.substring(0, $lastSlashIndex))
                   $parentPath
+                #end
+
+                 *#
+                #set($path = $item.uRI.replaceAll("^/","").replaceAll("/"," / ")))
+                #if($path.lastIndexOf(" / ") > 0)
+                  $path.substring(0, $path.lastIndexOf(" / "))
                 #end
               </td>
               <td>

--- a/ldregistry/templates/text-search.vm
+++ b/ldregistry/templates/text-search.vm
@@ -12,9 +12,10 @@
                 #end
 
                  *#
-                #set($path = $item.uRI.substring($registry.baseURI.length()).replaceAll("/"," / ")))
-                #if($path.lastIndexOf(" / ") > 0)
-                  $path.substring(0, $path.lastIndexOf(" / "))
+                #set($path = $item.uRI.substring($registry.baseURI.length()).replaceAll("^/","").replaceAll("/"," / ")))
+                #set($pathEndIndex = $path.lastIndexOf(" / "))
+                #if($pathEndIndex > 0)
+                  $path.substring(0, $pathEndIndex)
                 #end
               </td>
               <td>

--- a/ldregistry/ui/assets/js/locales/dataTables/en.json
+++ b/ldregistry/ui/assets/js/locales/dataTables/en.json
@@ -9,7 +9,7 @@
   "sLoadingRecords": "Loading...",
   "sProcessing": "Processing...",
   "sSearch": "Filter entries:",
-  "sZeroRecords": "No matching records found",
+  "sZeroRecords": "No matching records found. Please try the global search feature at the top of this page.",
   "oPaginate": {
 	"sFirst": "First",
 	"sLast": "Last",


### PR DESCRIPTION
Jira: [JAG-216](https://metoffice.atlassian.net/browse/JAG-216)
[JAG-240](https://metoffice.atlassian.net/browse/JAG-240)
[JAG-242](https://metoffice.atlassian.net/browse/JAG-242)

Description: 
 - JAG-216: Update the search results page to show a column for parent register, to make results clearer when multiple entries share the same notation. 
 - JAG-240: Update the text displayed when no results are found after using the search bar at the top of a register (rather than the global search at the top of the page), since it only filters the results contained in the displayed table, not any child registers.
 - JAG-242: Moving the hyperlink from the name column to the notation column, following a previous reordering of the columns.

Tasks:
- [x] Update text when no matching records found (`dataTables/en.json`)
- [x] Show parent register in search results (`text-search.vm`)
- [x] Make notation the hyperlink (`_render-register-as-list.vm`)
- [x] Test

Testing:
- Text when no records are found updated as expected
<img width="1081" height="174" alt="image" src="https://github.com/user-attachments/assets/413ca991-5b33-4bce-a629-bf66e9f7cc43" />

 - Can see parent register in search results
<img width="1167" height="743" alt="image" src="https://github.com/user-attachments/assets/c2ebe914-82d4-46c5-a9b4-c5ec20bc9231" />

- Hyperlink + directory logo has moved to notation column
<img width="978" height="440" alt="image" src="https://github.com/user-attachments/assets/b30eb0cc-d6fe-40f5-a573-fa407d2cfaa6" />



[JAG-216]: https://metoffice.atlassian.net/browse/JAG-216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JAG-240]: https://metoffice.atlassian.net/browse/JAG-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JAG-242]: https://metoffice.atlassian.net/browse/JAG-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ