### PR TITLE
Move hyperlink from name column to notation column

### DIFF
--- a/ldregistry/templates/main/_page-category.vm
+++ b/ldregistry/templates/main/_page-category.vm
@@ -54,10 +54,12 @@
             $entity.modelW.setLanguage($language)
 
           <tr>
-            <td>$item.getPropertyValue("reg:notation").lexicalForm</td>
             <td>
               #if($entity.hasResourceValue("rdf:type", "reg:Register"))<span class="glyphicon glyphicon-folder-open"></span> &nbsp; #end
-              <a href="#linkhref($item)" title="$item.uRI">$entity.name</a>
+              <a href="#linkhref($item)" title="$item.uRI">$item.getPropertyValue("reg:notation").lexicalForm</a>
+            </td>
+            <td>
+              $entity.name
             </td>
             <td>#tdescription($entity,"",70)</td>
 ##            <td> #foreach($ty in $entity.listPropertyValues("rdf:type"))#linkfor($ty)#if( $foreach.hasNext ), #end#end </td>


### PR DESCRIPTION
Jira: [JAG-242](https://metoffice.atlassian.net/browse/JAG-242)
### Description:
On deployment to CI, it was noticed that on the homepage, the hyperlink had not moved from the "Name" column to the "Notation" column:
<img width="640" height="301" alt="image" src="https://github.com/user-attachments/assets/c2dd3c44-9157-4bfa-8f4d-3dff68d14a0c" />

But had on all other pages:
<img width="1247" height="890" alt="image" src="https://github.com/user-attachments/assets/e0caf951-2537-4709-82a1-f0eef26ec9d9" />

This change fixes this, so that on all pages the hyperlink is in the "Notation" column.

### Tasks:
- [x] Move hyperlink

### Testing:
Deploying a dev instance, using a more recent registry backup to ensure this wasn't empty, the hyperlink appeared in the expected column on the [homepage](https://syrac.dev.codes.wmo.int/):
<img width="1448" height="643" alt="image" src="https://github.com/user-attachments/assets/1d7ba4fc-51a8-433e-89f4-3fb611221eac" />



[JAG-242]: https://metoffice.atlassian.net/browse/JAG-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ